### PR TITLE
argocd with secrets

### DIFF
--- a/ignition/argocd/argocd-cm.yaml
+++ b/ignition/argocd/argocd-cm.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  configManagementPlugins: |
+    - name: helmfile
+      generate:
+        command: ["/bin/sh", "-c"]
+        args: ["helmfile --namespace $ARGOCD_APP_NAMESPACE template | sed -e '1,/---/d' | sed -e 's|apiregistration.k8s.io/v1beta1|apiregistration.k8s.io/v1|g'"]
+  timeout.reconciliation: "15s"
+  kustomize.buildOptions: "--enable-alpha-plugins --enable-exec"
+  helm.valuesFileSchemes: >-
+      secrets+gpg-import, secrets+gpg-import-kubernetes,
+      secrets+age-import, secrets+age-import-kubernetes,
+      secrets,
+      https,http

--- a/ignition/argocd/argocd-repo-server-patch.yaml
+++ b/ignition/argocd/argocd-repo-server-patch.yaml
@@ -1,0 +1,29 @@
+# Use custom image
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: "antoinemartin/argocd-helmfile:latest"
+# Add user number (won't work with name)
+- op: add
+  path: /spec/template/spec/containers/0/securityContext/runAsUser
+  value: 999
+# Add sops secrets volume
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: argocd-sops-private-keys
+    secret:
+      secretName: argocd-sops-private-keys
+      optional: true
+      defaultMode: 420
+# Mount volume on server
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    mountPath: /sops-private-keys
+    name: argocd-sops-private-keys
+# Add environment variable to key file
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: SOPS_AGE_KEY_FILE
+    value: /sops-private-keys/age_key.txt

--- a/ignition/argocd/kustomization.yaml
+++ b/ignition/argocd/kustomization.yaml
@@ -7,16 +7,6 @@ resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 configMapGenerator:
-  - name: argocd-cm
-    behavior: merge
-    literals:
-      - "timeout.reconciliation=15s"
-      - |
-        configManagementPlugins=- name: helmfile
-          generate:
-            command: ["/bin/sh", "-c"]
-            args: ["helmfile --namespace $ARGOCD_APP_NAMESPACE template | sed -e '1,/---/d' | sed -e 's|apiregistration.k8s.io/v1beta1|apiregistration.k8s.io/v1|g'"]
-      - "kustomize.buildOptions=--enable-alpha-plugins --enable-exec"
   - name: argocd-cmd-params-cm
     behavior: merge
     literals:
@@ -26,13 +16,8 @@ generators:
   - sops-generator.yaml
 
 patches:
-  - patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: "antoinemartin/argocd-helmfile:latest"
-      - op: add
-        path: /spec/template/spec/containers/0/securityContext/runAsUser
-        value: 999
+  - path: argocd-repo-server-patch.yaml
     target:
       kind: Deployment
       name: argocd-repo-server
+  - path: argocd-cm.yaml

--- a/ignition/argocd/secrets.yaml
+++ b/ignition/argocd/secrets.yaml
@@ -7,10 +7,10 @@ metadata:
     namespace: argocd
 type: Opaque
 stringData:
-    type: ENC[AES256_GCM,data:xPmJ,iv:JyRiwYwNWnEZ9bM6Al9Pp0uiV6k7uM9vE0uRjwcJG+4=,tag:PGl6fjG+nEszih0xaLup3w==,type:str]
-    url: ENC[AES256_GCM,data:fTCOXuxZB0WqYMP8fqX7ZKWavg==,iv:OFjvJvnWBPqFGmRoIvBi6r8EfNjrhXAsjy4DzFMBAII=,tag:xb9yNHizCDSQEeL0afLTJg==,type:str]
-    username: ENC[AES256_GCM,data:DIL5av5tusE=,iv:TXMzFyrisIZ+vA7aFb2XfstA98/2CC+ydXeReFHlVT8=,tag:FYBV4VN7ithLMrDgEOxqhg==,type:str]
-    password: ENC[AES256_GCM,data:neYsu+Q7ZAkZJxHe+P7VNIqiM1px4p1K+JBtKTmzoweol6TUL+vY+w==,iv:gRM2a6pnz6iZCUyJWIkooUHidlYyVKT10JGpWIkKk9M=,tag:RukpD9uQWb+oFmGtMuaNHw==,type:str]
+    type: ENC[AES256_GCM,data:LFI3,iv:puiHOJiumKYIes6CWZI9MuZxDFn9cdKIvq6ehOTaw8o=,tag:oIiwRRzhqu+YyIk2VGAK6A==,type:str]
+    url: ENC[AES256_GCM,data:Z9mR1b6TSlr2JbtiYIhqt5cZtg==,iv:NWecLlSo4BuO1W5hOy2TZvXegtGOximYpOBEUpAdgOA=,tag:M+/4G1z/YehweAMsAqS4ZA==,type:str]
+    username: ENC[AES256_GCM,data:7MjNFbFvIVM=,iv:snQ7Bh2QONy3zVsjw0LzC22+hYbOiHKshRJyaIuwrhM=,tag:H0W7MvvUBwxNQVkBJ3ZX6Q==,type:str]
+    password: ENC[AES256_GCM,data:kFGV3w/QbF1O0sivCN85v8H7EJqt0CU3cvaM5CkmalwTMEKr9DT2Hw==,iv:5e4izYzCyQUMYtrnOKmqNZs5wOaHTOBbwN0fSi4z1f8=,tag:egwstLVx0KP5YdgMVqP0aA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -20,14 +20,43 @@ sops:
         - recipient: age1fs48f8rw9gj49ss5fapsy8euqln0dtrc5yg35fuq7c930jtkveps2swvt6
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSUjJUMi9QMk83dFJBVito
-            UHUxVkJXM0lFL2hOSFNmcHFKZnQydEtuemlRCnNWT3ZiZ1l0TTU4WWFCdStjY0da
-            cGY5WFFvMktrYzdUNzcwZmgrSlNuR1kKLS0tIGttaDF3bHdlLzBLTC9oTzYzcGc0
-            alFUVG1sVEQ4OXJyTHgzOXd1ZFJveTAKgNFMxc8nBk76qajdiKVPuLtjBFQ44Kub
-            8UP1A2ybzB5a/oTUT5yqKOfxR9/mgx9A374rg9RIFwvQdsddai8D9w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cS9HM2lTUmJ3WDkyemcx
+            dnZ3MTUxRkkxWjZoZnY1K0xlbzd5UEVscGdnClVuZFIwQzNoKzV0TFN2NkJvdk9Y
+            eUxVazJ5aFBkOXFyYTBXTVlnMzREUXMKLS0tIHo5MzRkTGVyY295WmlGOUc0Rmh5
+            R0hMZWYzVmcvTUwxTlFsaStyWFNLbGsKa8XXJmR0uAXZxwe4nZOua0zh3d8PFG1T
+            Hbo2sTjALBPn2lgTNLFHho7IWmvsrrUnhl4siCT1GPXE1764YEw9gw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-05-16T15:41:27Z"
-    mac: ENC[AES256_GCM,data:13vTP6KK+f/ytvu6i/higOVJUMwGCjqfpvqjzgk1jV6GNN8lu++F+qfGMth/vLs8CJhZ71/+Bf1hScKmywZYltffyNrn6CFV37QIhyTO3V2swHGfaAx9SQAo7Nvn+cUdIVc47bknMUkAWb04mcMlY7oU+fusa3hpTU6TbyeY8iw=,iv:gP52Ua2ZyXRG4RvXlBB1eqU8bDL7fbQNUH7b0Y1sZY4=,tag:hUqkt8y+bcnnZ+NfhqnnSg==,type:str]
+    lastmodified: "2022-05-17T16:14:30Z"
+    mac: ENC[AES256_GCM,data:ImjbwN0g8SmJ6EJ9+G9bSe6mVQAW38ZahIvCVCG8JkHtIMQi0o2OQt18MF30Vot+A34NlZdvDyyVyCHIHoDluZc5I/XH3R51X/D9a5rDCUj+vTx6pdDx4wyzk5gIdubtC0ClW9f+drwzNo/t4JDp9d3/r5lDw2SNSrGFq617wgE=,iv:W6ibTwXHbAQAE9AXSFCKPdJa1iFsbj4ueFdd9jIzVxw=,tag:C2HQt6c+LC94ThUl/lE1Jg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: argocd-sops-private-keys
+    namespace: argocd
+type: Opaque
+data:
+    age_key.txt: ENC[AES256_GCM,data:/AqW9ao56x3995YA25ZTqRYW4OLAED0FgmLzSqYFSbCKx9xCtXiJ5x6E77vwW2vwD93R8Esz8ZtJiDJ0BkpleaEivUewKydP366KoN5oA5/pV6C5RgAsAG7nC48KHtJ80q+4IuQH26ftA1QQBoEdVNKHdtLwUCJK7Rqp09JM14bWqd1+G5bzUu/2zNPOYPMp6OLXgtaug8VIdxSJ0Jwl3dF2yvBi7Rg4PCVtNFbwn1FC4Z7GX6mU9Q6trbtNsMF0SpjoxUialRa/xc7p2wPo4gVpcyPpOqF2RHXBhNTo2rwi4PQVhM29+pmErl++WVwGC2oHZNemJ60=,iv:2pR2sYcE2J4X+dhoLdYFBd6e3Z927t91qIKCyzcsw5A=,tag:4CScPzmH1apjrEjh4k8i6Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1fs48f8rw9gj49ss5fapsy8euqln0dtrc5yg35fuq7c930jtkveps2swvt6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cS9HM2lTUmJ3WDkyemcx
+            dnZ3MTUxRkkxWjZoZnY1K0xlbzd5UEVscGdnClVuZFIwQzNoKzV0TFN2NkJvdk9Y
+            eUxVazJ5aFBkOXFyYTBXTVlnMzREUXMKLS0tIHo5MzRkTGVyY295WmlGOUc0Rmh5
+            R0hMZWYzVmcvTUwxTlFsaStyWFNLbGsKa8XXJmR0uAXZxwe4nZOua0zh3d8PFG1T
+            Hbo2sTjALBPn2lgTNLFHho7IWmvsrrUnhl4siCT1GPXE1764YEw9gw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-05-17T16:14:30Z"
+    mac: ENC[AES256_GCM,data:ImjbwN0g8SmJ6EJ9+G9bSe6mVQAW38ZahIvCVCG8JkHtIMQi0o2OQt18MF30Vot+A34NlZdvDyyVyCHIHoDluZc5I/XH3R51X/D9a5rDCUj+vTx6pdDx4wyzk5gIdubtC0ClW9f+drwzNo/t4JDp9d3/r5lDw2SNSrGFq617wgE=,iv:W6ibTwXHbAQAE9AXSFCKPdJa1iFsbj4ueFdd9jIzVxw=,tag:C2HQt6c+LC94ThUl/lE1Jg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3

--- a/repo-server/Dockerfile
+++ b/repo-server/Dockerfile
@@ -29,20 +29,20 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     # kubectl
-    curl -so /usr/local/bin/kubectl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+    curl -sLo /usr/local/bin/kubectl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     # helm
-    curl -sOL ${HELM_LOCATION}/${HELM_FILENAME} && \
+    curl -sLO ${HELM_LOCATION}/${HELM_FILENAME} && \
     tar zxvf ${HELM_FILENAME} && mv ./linux-amd64/helm /usr/local/bin/ && \
     rm ${HELM_FILENAME} && rm -r ./linux-amd64 && \
     # helmfile
-    curl -so /usr/local/bin/helmfile -L https://github.com/roboll/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_linux_amd64 && \
+    curl -sLo /usr/local/bin/helmfile -L https://github.com/roboll/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_linux_amd64 && \
     # sops
-    curl -so /usr/local/bin/sops -L https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64 && \
+    curl -sLo /usr/local/bin/sops -L https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64 && \
     # Kustomize
     curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar zxf - && \ 
     mv kustomize /usr/local/bin && \
     # krmfnsops
-    curl -so /usr/local/bin/krmfnsops https://github.com/kaweezle/krmfnsops/releases/download/${KRMFNSOPS_VERSION}/krmfnsops_${KRMFNSOPS_VERSION}_linux_amd64 && \
+    curl -sLo /usr/local/bin/krmfnsops https://github.com/kaweezle/krmfnsops/releases/download/${KRMFNSOPS_VERSION}/krmfnsops_${KRMFNSOPS_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/helm && \
     chmod +x /usr/local/bin/helmfile && \


### PR DESCRIPTION
Change the configuration of ArgoCD in order to accept kustomize based applications that contain secrets encrypted with sops. 

When ArgoCD id first deployed (without ArgoCD), secrets are decrypted and deployed with krmfnsops. For automanagement to work, the secret key and the tools used for decyphering need to be available inside argocd-repo-server.

This MR does just that.